### PR TITLE
Rewrite UART and SPI drivers

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,11 @@ authors = ["Pepijn de Vos <pepijndevos@gmail.com>"]
 edition = "2018"
 
 [dependencies]
+litex-pac = { path = "../litex-pac" }
+embedded-hal = "0.2.4"
+nb = "0.1.1"
+
+[features]
+default = ["uart", "oled_spi"]
+uart = []
+oled_spi = []

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,0 +1,44 @@
+use core::ops::Deref;
+use litex_pac::oled_spi::RegisterBlock;
+
+pub struct SPI {
+    registers: &'static RegisterBlock
+}
+
+impl SPI {
+    pub fn new<SPI: Deref<Target=RegisterBlock>>(spi: SPI) -> Self {
+        Self {
+            registers: unsafe { &*(spi.deref() as *const RegisterBlock) }
+        }
+    }
+}
+
+impl embedded_hal::spi::FullDuplex<u8> for SPI {
+    type Error = core::convert::Infallible;
+
+    fn read(&mut self) -> nb::Result<u8, Self::Error> {
+        if self.registers.status.read().done().bit() {
+            Ok(self.registers.miso.read().bits() as u8)
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+
+    fn send(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        if self.registers.status.read().done().bit() {
+            unsafe {
+                self.registers.mosi.write(|w| w.bits(word.into()));
+                self.registers.control.write(|w| {
+                    w.length().bits(8).start().bit(true)
+                });
+            }
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+}
+
+impl embedded_hal::blocking::spi::write::Default<u8> for SPI {}
+//impl embedded_hal::blocking::spi::write_iter::Default<u8> for SPI {}
+impl embedded_hal::blocking::spi::transfer::Default<u8> for SPI {}

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -1,0 +1,40 @@
+use core::ops::Deref;
+use litex_pac::uart::RegisterBlock;
+
+pub struct UART {
+    registers: &'static RegisterBlock
+}
+
+impl UART {
+    pub fn new<UART: Deref<Target=RegisterBlock>>(uart: UART) -> Self {
+        Self {
+            registers: unsafe { &*(uart.deref() as *const RegisterBlock) }
+        }
+    }
+}
+
+impl embedded_hal::serial::Write<u8> for UART {
+    type Error = core::convert::Infallible;
+
+    fn write(&mut self, word: u8) -> nb::Result<(), Self::Error> {
+        // Wait until TXFULL is `0`
+        if self.registers.txfull.read().bits() != 0 {
+            Err(nb::Error::WouldBlock)
+        } else {
+            unsafe {
+                self.registers.rxtx.write(|w| w.rxtx().bits(word.into()));
+            }
+            Ok(())
+        }
+    }
+
+    fn flush(&mut self) -> nb::Result<(), Self::Error> {
+        if self.registers.txempty.read().bits() != 0 {
+            Ok(())
+        } else {
+            Err(nb::Error::WouldBlock)
+        }
+    }
+}
+
+impl embedded_hal::blocking::serial::write::Default<u8> for UART {}


### PR DESCRIPTION
To use any of the drivers for multiple identical peripherals, you need to apply a simple patch that adds a `derivedFrom` directive: https://github.com/Disasm/rust-litex-pac/blob/master/iCEBESOC.yaml