### PR TITLE
Extend generated code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,6 +8,7 @@ macro_rules! uart {
         $UARTX:ident: $PACUARTX:ty,
     )+) => {
         $(
+            #[derive(Debug)]
             pub struct $UARTX {
                 registers: $PACUARTX,
             }
@@ -66,6 +67,7 @@ macro_rules! gpio {
         $GPIOX:ident: $PACGPIOX:ty,
     )+) => {
         $(
+            #[derive(Debug)]
             pub struct $GPIOX {
                 pub index: usize,
             }
@@ -132,6 +134,7 @@ macro_rules! spi {
         $SPIX:ident: ($PACSPIX:ty, $WORD:ty),
     )+) => {
         $(
+            #[derive(Debug)]
             pub struct $SPIX {
                 registers: $PACSPIX,
             }
@@ -186,6 +189,7 @@ macro_rules! timer {
         $TIMERX:ident: $PACTIMERX:ty,
     )+) => {
         $(
+            #[derive(Debug)]
             pub struct $TIMERX {
                 registers: $PACTIMERX,
                 pub sys_clk: u32,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,17 @@ macro_rules! uart {
     )+) => {
         $(
             pub struct $UARTX {
-                pub registers: $PACUARTX,
+                registers: $PACUARTX,
+            }
+
+            impl $UARTX {
+                pub fn new(registers: $PACUARTX) -> Self {
+                    Self { registers }
+                }
+
+                pub fn free(self) -> $PACUARTX {
+                    self.registers
+                }
             }
 
             impl embedded_hal::serial::Write<u8> for $UARTX {
@@ -58,6 +68,12 @@ macro_rules! gpio {
         $(
             pub struct $GPIOX {
                 pub index: usize,
+            }
+
+            impl $GPIOX {
+                pub fn new(index: usize) -> Self {
+                    Self { index }
+                }
             }
 
             impl embedded_hal::digital::v2::OutputPin for $GPIOX {
@@ -117,7 +133,17 @@ macro_rules! spi {
     )+) => {
         $(
             pub struct $SPIX {
-                pub registers: $PACSPIX,
+                registers: $PACSPIX,
+            }
+
+            impl $SPIX {
+                pub fn new(registers: $PACSPIX) -> Self {
+                    Self { registers }
+                }
+
+                pub fn free(self) -> $PACSPIX {
+                    self.registers
+                }
             }
 
             impl embedded_hal::spi::FullDuplex<$WORD> for $SPIX {
@@ -162,8 +188,18 @@ macro_rules! timer {
     )+) => {
         $(
             pub struct $TIMERX {
-                pub registers: $PACTIMERX,
+                registers: $PACTIMERX,
                 pub sys_clk: u32,
+            }
+
+            impl $TIMERX {
+                pub fn new(registers: $PACTIMERX, sys_clk: u32) -> Self {
+                    Self { registers, sys_clk }
+                }
+
+                pub fn free(self) -> $PACTIMERX {
+                    self.registers
+                }
             }
 
             impl<UXX: core::convert::Into<u32>> embedded_hal::blocking::delay::DelayMs<UXX> for $TIMERX {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -55,6 +55,12 @@ macro_rules! uart {
                     Ok(())
                 }
             }
+
+            impl From<$PACUARTX> for $UARTX {
+                fn from(registers: $PACUARTX) -> $UARTX {
+                    $UARTX::new(registers)
+                }
+            }
         )+
     }
 }
@@ -177,6 +183,12 @@ macro_rules! spi {
 
             impl embedded_hal::blocking::spi::write::Default<u8> for $SPIX {}
             impl embedded_hal::blocking::spi::transfer::Default<u8> for $SPIX {}
+
+            impl From<$PACSPIX> for $SPIX {
+                fn from(registers: $PACSPIX) -> $SPIX {
+                    $SPIX::new(registers)
+                }
+            }
         )+
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,6 @@ macro_rules! spi {
             }
 
             impl embedded_hal::blocking::spi::write::Default<u8> for $SPIX {}
-            //impl embedded_hal::blocking::spi::write_iter::Default<u8> for $SPIX {}
             impl embedded_hal::blocking::spi::transfer::Default<u8> for $SPIX {}
         )+
     }
@@ -203,8 +202,6 @@ macro_rules! timer {
             }
 
             impl<UXX: core::convert::Into<u32>> embedded_hal::blocking::delay::DelayMs<UXX> for $TIMERX {
-                //type Error = Infallible;
-
                 fn delay_ms(&mut self, ms: UXX) -> () {
                     let value: u32 = self.sys_clk / 1_000 * ms.into();
                     unsafe {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,6 +36,14 @@ macro_rules! uart {
             }
 
             impl embedded_hal::blocking::serial::write::Default<u8> for $UARTX {}
+
+            impl core::fmt::Write for $UARTX {
+                fn write_str(&mut self, s: &str) -> core::fmt::Result {
+                    use embedded_hal::prelude::*;
+                    self.bwrite_all(s.as_bytes()).ok();
+                    Ok(())
+                }
+            }
         )+
     }
 }
@@ -146,7 +154,6 @@ macro_rules! spi {
 }
 
 // Delay
-
 
 #[macro_export]
 macro_rules! timer {


### PR DESCRIPTION
@pepijndevos thank you for providing this crate, it's a good place to start working with LiteX.
This PR contains the following changes:
1. Implement `core::fmt::Write` for UART. With this change it's possible to use UART like this:
```rust
writeln!(uart, "Hello, {}", "world");
```
2. Add constructors and destructors as [recommended](https://doc.rust-lang.org/beta/embedded-book/design-patterns/hal/interoperability.html?highlight=free#wrapper-types-provide-a-destructor-method-c-free) by the Embedded book.
3. Add `Debug` derive to be able to use `unwrap()` and `expect()` on `Option<Device>`.
4. Add `From` impl.