### PR TITLE
Fix clippy errors from embedded-io update

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ bench = false
 [dependencies]
 nb = "1.0"
 embedded-hal = { version = "1.0" }
-embedded-io = "0.6.1"
+embedded-io = "0.7.1"
 
 [dev-dependencies]
 litex-sim-pac = { path = "litex-sim-pac" }

--- a/src/uart.rs
+++ b/src/uart.rs
@@ -14,6 +14,16 @@ macro_rules! uart {
                 InvalidState
             }
 
+            impl core::fmt::Display for UartError {
+                fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+                    match self {
+                        UartError::InvalidState => write!(f, "invalid state"),
+                    }
+                }
+            }
+
+            impl core::error::Error for UartError {}
+
             impl $crate::hal_io::Error for UartError {
                 fn kind(&self) -> $crate::hal_io::ErrorKind {
                     $crate::hal_io::ErrorKind::Other


### PR DESCRIPTION
Implement core::error::Error for UartError as required by embedded-io 0.7's breaking change (Error trait now requires core::error::Error).